### PR TITLE
Don't await closing clients

### DIFF
--- a/src/eventHub.test.ts
+++ b/src/eventHub.test.ts
@@ -26,12 +26,10 @@ describe('eventHub', () => {
     });
 
     after(async () => {
-        await Promise.all([
-            clientOneTriggerAndOutput.close(),
-            clientOneTrigger.close(),
-            clientManyTriggerAndOutput.close(),
-            clientManyTrigger.close(),
-        ]);
+        void clientOneTriggerAndOutput.close();
+        void clientOneTrigger.close();
+        void clientManyTriggerAndOutput.close();
+        void clientManyTrigger.close();
     });
 
     describe('cardinality one', () => {

--- a/src/serviceBus.test.ts
+++ b/src/serviceBus.test.ts
@@ -21,7 +21,7 @@ describe('serviceBus', () => {
     });
 
     after(async () => {
-        await client.close();
+        void client.close();
     });
 
     it('queue trigger and output', async () => {


### PR DESCRIPTION
Occasionally seeing this error in the tests

```
eventHub
       "after all" hook in "eventHub":
     Error: Timeout of 180000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/1/s/out/eventHub.test.js)
      at listOnTimeout (node:internal/timers:569:17)
      at process.processTimers (node:internal/timers:512:7)
```

But there's no particular reason we need to wait for these clients to close