### PR TITLE
Ensure timely exit of process after test run finishes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ export async function run(): Promise<void> {
         if (failures > 0) {
             throw new Error(`${failures} tests failed.`);
         }
+        console.log('Test run succeeded');
+        process.exit(0);
     } catch (err) {
         console.error(err);
         console.error('Test run failed');


### PR DESCRIPTION
We already call `process.exit` if the test run failed (on line 43 which is cutoff in the diff), so I just updated the successful case to also call `process.exit`.

Related to https://github.com/Azure/azure-functions-nodejs-e2e-tests/pull/28, since this will force clean up anything that wasn't cleaned up yet. I simulated this on my local machine by temporarily removing the calls to `client.close` (since I couldn't actually repro the flaky timeouts on my local machine). Without my PR change the process will continue to run indefinitely because the clients are holding on to something (which is what leads to a timeout in a [CI run](https://azfunc.visualstudio.com/Azure%20Functions/_build/results?buildId=157419&view=results)) and with my PR change it exited immediately and worked great.