### PR TITLE
Add test for shared output bug

### DIFF
--- a/app/v4/src/functions/storageBlobTriggerSharedOutputBug.ts
+++ b/app/v4/src/functions/storageBlobTriggerSharedOutputBug.ts
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import { app, InvocationContext, output } from '@azure/functions';
+
+// Test for bug https://github.com/Azure/azure-functions-nodejs-library/issues/179
+
+const queueOutput = output.storageQueue({
+    queueName: 'e2e-test-queue-trigger',
+    connection: 'e2eTest_storage',
+});
+
+app.storageBlob('storageBlobTriggerReturnOutput', {
+    path: 'e2e-test-container/e2e-test-blob-trigger-shared-output-bug',
+    connection: 'e2eTest_storage',
+    return: queueOutput,
+    handler: (blob: Buffer, context: InvocationContext) => {
+        context.log(`storageBlobTriggerReturnOutput was triggered`);
+        return `${blob.toString()}-returnOutput`;
+    },
+});
+
+app.storageBlob('storageBlobTriggerExtraOutput', {
+    path: 'e2e-test-container/e2e-test-blob-trigger-shared-output-bug',
+    connection: 'e2eTest_storage',
+    extraOutputs: [queueOutput],
+    handler: (blob: Buffer, context: InvocationContext) => {
+        context.log(`storageBlobTriggerExtraOutput was triggered`);
+        context.extraOutputs.set(queueOutput, `${blob.toString()}-extraOutput`);
+    },
+});

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -6,7 +6,7 @@ import { QueueClient } from '@azure/storage-queue';
 import { expect } from 'chai';
 import { default as fetch } from 'node-fetch';
 import { getFuncUrl } from './constants';
-import { waitForOutput } from './global.test';
+import { model, waitForOutput } from './global.test';
 import { storageConnectionString } from './resources/connectionStrings';
 import { getRandomTestData } from './utils/getRandomTestData';
 
@@ -82,5 +82,26 @@ describe('storage', () => {
         const result = await responseIn.json();
         expect(result).to.deep.equal(items);
         await waitForOutput(`httpTriggerTableInput was triggered`);
+    });
+
+    // Test for bug https://github.com/Azure/azure-functions-nodejs-library/issues/179
+    it('Shared output bug', async function (this: Mocha.Context) {
+        if (model === 'v3') {
+            this.skip();
+        }
+
+        const containerName = 'e2e-test-container';
+        const client = new ContainerClient(storageConnectionString, containerName);
+        await client.createIfNotExists();
+
+        const message = getRandomTestData();
+        const messageBuffer = Buffer.from(message);
+        const blobName = 'e2e-test-blob-trigger-shared-output-bug';
+        await client.uploadBlockBlob(blobName, messageBuffer, messageBuffer.byteLength);
+
+        await waitForOutput(`storageBlobTriggerReturnOutput was triggered`);
+        await waitForOutput(`storageBlobTriggerExtraOutput was triggered`);
+        await waitForOutput(`storageQueueTrigger was triggered by "${message}-returnOutput"`);
+        await waitForOutput(`storageQueueTrigger was triggered by "${message}-extraOutput"`);
     });
 });


### PR DESCRIPTION
Related to https://github.com/Azure/azure-functions-nodejs-library/issues/179

This test should fail until we merge [the fix](https://github.com/Azure/azure-functions-nodejs-library/pull/193) in the library package