### PR TITLE
Use Az CLI for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,7 @@ Here is the general flow of the pipeline:
 You need to create resources once in your subscription, but then you can reuse the same resources for many different test runs. The CI pipeline will create and delete resources each time, but you don't need to do that.
 
 1. Set the environment variable `BUILD_BUILDNUMBER` to any number like `20230520.1`. You want it to be reasonably unique because this will be used as a prefix for your Azure resources.
-2. [Create a service principal](https://learn.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal) and give it access to create resources in your subscription. Set the following environment variables based on the service principal:
-    - `AZURE_TENANT_ID`
-    - `AZURE_CLIENT_ID`
-    - `AZURE_CLIENT_SECRET`
-    - `AZURE_SUBSCRIPTION_ID`
+2. Run `az login` and `az account set -s <subscription id>` if you're not already logged in to the [Azure CLI](https://learn.microsoft.com/cli/azure/get-started-with-azure-cli). The tests will use these credentials.
 3. Run `npm run createResources`
 4. Validate the resources were created. You should see a resource group in your subscription like `e2edarwin202305201group` with several resources
 

--- a/azure-pipelines/test.yml
+++ b/azure-pipelines/test.yml
@@ -55,13 +55,13 @@ jobs:
           - script: npm run lint
             displayName: 'lint e2e tests'
 
-          - script: npm run createResources
+          - task: AzureCLI@2
             displayName: 'Create resources'
-            env:
-                AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-                AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-                AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-                AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            inputs:
+                azureSubscription: 'azure-functions-nodejs-e2e-tests'
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: 'npm run createResources'
 
           # Setup v3 app
           - script: npm ci
@@ -130,14 +130,14 @@ jobs:
                 versionSpec: 16.x
             displayName: 'Install Node 16'
             retryCountOnTaskFailure: 10
-          - script: npm test
+          - task: AzureCLI@2
             displayName: 'Run tests Node 16'
             continueOnError: true
-            env:
-                AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-                AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-                AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-                AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            inputs:
+                azureSubscription: 'azure-functions-nodejs-e2e-tests'
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: 'npm test'
 
           # Run tests Node 18
           - task: NodeTool@0
@@ -145,24 +145,24 @@ jobs:
                 versionSpec: 18.x
             displayName: 'Install Node 18'
             retryCountOnTaskFailure: 10
-          - script: npm test
+          - task: AzureCLI@2
             displayName: 'Run tests Node 18'
             continueOnError: true
-            env:
-                AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-                AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-                AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-                AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            inputs:
+                azureSubscription: 'azure-functions-nodejs-e2e-tests'
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: 'npm test'
 
           # Run tests for old config (just one Node.js version is enough)
-          - script: npm run testOldConfig
+          - task: AzureCLI@2
             displayName: 'Run tests old config'
             continueOnError: true
-            env:
-                AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-                AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-                AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-                AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            inputs:
+                azureSubscription: 'azure-functions-nodejs-e2e-tests'
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: 'npm run testOldConfig'
 
           # Run tests Node 20
           - task: NodeTool@0
@@ -170,22 +170,22 @@ jobs:
                 versionSpec: 20.x
             displayName: 'Install Node 20'
             retryCountOnTaskFailure: 10
-          - script: npm test
+          - task: AzureCLI@2
             displayName: 'Run tests Node 20'
             continueOnError: true
-            env:
-                AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-                AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-                AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-                AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            inputs:
+                azureSubscription: 'azure-functions-nodejs-e2e-tests'
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: 'npm test'
 
-          - script: npm run deleteResources
+          - task: AzureCLI@2
             displayName: 'Delete resources'
-            env:
-                AZURE_TENANT_ID: $(AZURE_TENANT_ID)
-                AZURE_CLIENT_ID: $(AZURE_CLIENT_ID)
-                AZURE_CLIENT_SECRET: $(AZURE_CLIENT_SECRET)
-                AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            inputs:
+                azureSubscription: 'azure-functions-nodejs-e2e-tests'
+                scriptType: 'bash'
+                scriptLocation: 'inlineScript'
+                inlineScript: 'npm run deleteResources'
             condition: succeededOrFailed()
 
           - task: PublishTestResults@2

--- a/src/resources/ResourceInfo.ts
+++ b/src/resources/ResourceInfo.ts
@@ -1,15 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License.
 
-import { EnvironmentCredential } from '@azure/identity';
+import { DefaultAzureCredential } from '@azure/identity';
+import { getSubscriptionId, getUserId, getUserName } from '../utils/azureCli';
 import { validateEnvVar } from '../utils/validateEnvVar';
 
 export interface ResourceInfo {
-    creds: EnvironmentCredential;
+    creds: DefaultAzureCredential;
     subscriptionId: string;
-    tenantId: string;
-    clientId: string;
-    secret: string;
+    userName: string;
+    userId: string;
     resourceGroupName: string;
     resourcePrefix: string;
     location: string;
@@ -22,21 +22,20 @@ function getResourcePrefix(): string {
     return result.replace(/[^0-9a-zA-Z]/g, '');
 }
 
-export function getResourceInfo(): ResourceInfo {
-    const tenantId = validateEnvVar('AZURE_TENANT_ID');
-    const clientId = validateEnvVar('AZURE_CLIENT_ID');
-    const secret = validateEnvVar('AZURE_CLIENT_SECRET');
-    const subscriptionId: string = validateEnvVar('AZURE_SUBSCRIPTION_ID');
-    const resourcePrefix = getResourcePrefix();
+export async function getResourceInfo(): Promise<ResourceInfo> {
+    const creds = new DefaultAzureCredential();
 
-    const creds = new EnvironmentCredential();
+    const subscriptionId = await getSubscriptionId();
+    const userName = await getUserName();
+    const userId = await getUserId(userName);
+
+    const resourcePrefix = getResourcePrefix();
 
     return {
         creds,
-        tenantId,
-        clientId,
-        secret,
         subscriptionId,
+        userName,
+        userId,
         resourcePrefix,
         resourceGroupName: resourcePrefix + 'group',
         location: 'eastus',

--- a/src/resources/connectionStrings.ts
+++ b/src/resources/connectionStrings.ts
@@ -17,7 +17,7 @@ export let sqlConnectionString: string;
 export let sqlConnectionConfig: sql.config;
 
 export async function initializeConnectionStrings(): Promise<void> {
-    const info = getResourceInfo();
+    const info = await getResourceInfo();
     [
         storageConnectionString,
         eventHubConnectionString,

--- a/src/resources/createResources.ts
+++ b/src/resources/createResources.ts
@@ -11,7 +11,7 @@ import { createStorageAccount } from './storage';
 
 async function createResources(): Promise<void> {
     try {
-        const info = getResourceInfo();
+        const info = await getResourceInfo();
 
         const resourceClient = new ResourceManagementClient(info.creds, info.subscriptionId);
         await resourceClient.resourceGroups.createOrUpdate(info.resourceGroupName, { location: info.location });

--- a/src/resources/deleteResources.ts
+++ b/src/resources/deleteResources.ts
@@ -6,7 +6,7 @@ import { getResourceInfo } from './ResourceInfo';
 
 async function deleteResources(): Promise<void> {
     try {
-        const info = getResourceInfo();
+        const info = await getResourceInfo();
 
         const resourceClient = new ResourceManagementClient(info.creds, info.subscriptionId);
         await resourceClient.resourceGroups.beginDelete(info.resourceGroupName);

--- a/src/resources/sql.ts
+++ b/src/resources/sql.ts
@@ -30,11 +30,10 @@ export async function createSql(info: ResourceInfo): Promise<void> {
         location: info.location,
         administrators: {
             administratorType: 'ActiveDirectory',
-            principalType: 'Application',
-            sid: info.clientId,
-            tenantId: info.tenantId,
+            principalType: 'User',
+            sid: info.userId,
             azureADOnlyAuthentication: true,
-            login: 'e2eserviceprincipal',
+            login: info.userName,
         },
     });
 
@@ -116,7 +115,7 @@ export async function createPoolConnnection(config: sql.config): Promise<sql.Con
 
 export async function getSqlConnectionString(info: ResourceInfo): Promise<string> {
     const serverName = getSqlAccountName(info);
-    return `Server=${serverName}.database.windows.net; Authentication=Active Directory Service Principal; Encrypt=True; Database=${dbName}; User Id=${info.clientId}; Password=${info.secret}`;
+    return `Server=${serverName}.database.windows.net; Authentication=Active Directory Default; Encrypt=True; Database=${dbName};`;
 }
 
 /**
@@ -130,12 +129,8 @@ export function getSqlConnectionConfig(info: ResourceInfo): sql.config {
         database: dbName,
         port: 1433,
         authentication: {
-            type: 'azure-active-directory-service-principal-secret',
-            options: <any>{
-                clientId: info.clientId,
-                tenantId: info.tenantId,
-                clientSecret: info.secret,
-            },
+            type: 'azure-active-directory-default',
+            options: {},
         },
         options: {
             encrypt: true,

--- a/src/utils/azureCli.ts
+++ b/src/utils/azureCli.ts
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as cp from 'child_process';
+
+export async function getSubscriptionId(): Promise<string> {
+    return executeCommand('az account show --query id -o tsv');
+}
+
+export async function getUserName(): Promise<string> {
+    return executeCommand('az account show --query user.name -o tsv');
+}
+
+export async function getUserId(userName: string): Promise<string> {
+    const userType = await executeCommand('az account show --query user.type -o tsv');
+    if (userType === 'user') {
+        return executeCommand(`az ad user show --id ${userName} --query id -o tsv`);
+    } else {
+        // In Azure Pipelines the userType will be 'servicePrincipal' and the userName will already be the id we need
+        return userName;
+    }
+}
+
+async function executeCommand(command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        let stdout = '';
+
+        const childProc = cp.spawn(command, { shell: true });
+
+        childProc.stdout?.on('data', (data) => {
+            stdout += data.toString();
+        });
+
+        childProc.stderr?.on('data', (data) => {
+            console.error(data.toString());
+        });
+
+        childProc.on('error', reject);
+        childProc.on('close', (code: number) => {
+            if (code === 0) {
+                resolve(stdout.trim());
+            } else {
+                reject(new Error(`Command "${command}" failed with exit code ${code}`));
+            }
+        });
+    });
+}


### PR DESCRIPTION
Service principal secrets are discouraged now, so switching to use the Az CLI to get creds for us. If you're runnning locally you just do `az login` and it magically works. For Azure Pipelines it still uses the Az CLI, but it references a new [service connection](https://learn.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints?view=azure-devops&tabs=yaml) that I created for logging in.