### PR TITLE
Fix create resource errors

### DIFF
--- a/src/resources/ResourceInfo.ts
+++ b/src/resources/ResourceInfo.ts
@@ -43,6 +43,6 @@ export async function getResourceInfo(): Promise<ResourceInfo> {
         objectId,
         resourcePrefix,
         resourceGroupName: resourcePrefix + 'group',
-        location: 'eastus',
+        location: 'westus',
     };
 }

--- a/src/resources/storage.ts
+++ b/src/resources/storage.ts
@@ -18,6 +18,7 @@ export async function createStorageAccount(info: ResourceInfo): Promise<void> {
         sku: {
             name: KnownSkuName.StandardLRS,
         },
+        allowBlobPublicAccess: false,
     });
 
     const connectionString = await getStorageConnectionString(info);


### PR DESCRIPTION
Fixes the following recent errors when creating resources:

> Database account creation failed. Sorry, we are currently experiencing high demand in East US region, and cannot fulfill your request at this time.

> Resource was disallowed by policy. Storage account public access should be disallowed